### PR TITLE
Add project path to get_project_info command

### DIFF
--- a/addons/godot_mcp/commands/project_commands.gd
+++ b/addons/godot_mcp/commands/project_commands.gd
@@ -24,6 +24,7 @@ func process_command(client_id: int, command_type: String, params: Dictionary, c
 func _get_project_info(client_id: int, _params: Dictionary, command_id: String) -> void:
 	var project_name = ProjectSettings.get_setting("application/config/name", "Untitled Project")
 	var project_version = ProjectSettings.get_setting("application/config/version", "1.0.0")
+	var project_path = ProjectSettings.globalize_path("res://")
 	
 	# Get Godot version info and structure it as expected by the server
 	var version_info = Engine.get_version_info()
@@ -39,6 +40,7 @@ func _get_project_info(client_id: int, _params: Dictionary, command_id: String) 
 	_send_success(client_id, {
 		"project_name": project_name,
 		"project_version": project_version,
+		"project_path": project_path,
 		"godot_version": structured_version,
 		"current_scene": get_tree().edited_scene_root.scene_file_path if get_tree().edited_scene_root else ""
 	}, command_id)

--- a/server/src/tools/scene_tools.ts
+++ b/server/src/tools/scene_tools.ts
@@ -118,6 +118,7 @@ export const sceneTools: MCPTool[] = [
         
         let output = `Project Name: ${result.project_name}\n`;
         output += `Project Version: ${result.project_version}\n`;
+        output += `Project Path: ${result.project_path}\n`;
         output += `Godot Version: ${godotVersion}\n`;
         
         if (result.current_scene) {


### PR DESCRIPTION
The full project path is required to save assets from external tools such as blender into the project.
Because currently godot doesn't allow you to get the result of @GlobalScope.print from a gdscript.
If a script based logger is implemented, I think it will be possible to obtain logs from the mcp server.
https://github.com/godotengine/godot/pull/99811