### PR TITLE
Start stdio transport before Godot WebSocket connect

### DIFF
--- a/server/dist/index.js
+++ b/server/dist/index.js
@@ -47,6 +47,7 @@ import { FastMCP } from 'fastmcp';
 import { nodeTools } from './tools/node_tools.js';
 import { scriptTools } from './tools/script_tools.js';
 import { sceneTools } from './tools/scene_tools.js';
+import { editorTools } from './tools/editor_tools.js';
 import { getGodotConnection } from './utils/godot_connection.js';
 // Import resources
 import { sceneListResource, sceneStructureResource } from './resources/scene_resources.js';
@@ -58,63 +59,53 @@ import { editorStateResource, selectedNodeResource, currentScriptResource } from
  */
 function main() {
     return __awaiter(this, void 0, void 0, function () {
-        var server, godot, error_1, err, cleanup;
+        var server, godot, cleanup;
         return __generator(this, function (_a) {
-            switch (_a.label) {
-                case 0:
-                    console.error('Starting Godot MCP server...');
-                    server = new FastMCP({
-                        name: 'GodotMCP',
-                        version: '1.0.0',
-                    });
-                    // Register all tools
-                    __spreadArray(__spreadArray(__spreadArray([], nodeTools, true), scriptTools, true), sceneTools, true).forEach(function (tool) {
-                        server.addTool(tool);
-                    });
-                    // Register all resources
-                    // Static resources
-                    server.addResource(sceneListResource);
-                    server.addResource(scriptListResource);
-                    server.addResource(projectStructureResource);
-                    server.addResource(projectSettingsResource);
-                    server.addResource(projectResourcesResource);
-                    server.addResource(editorStateResource);
-                    server.addResource(selectedNodeResource);
-                    server.addResource(currentScriptResource);
-                    server.addResource(sceneStructureResource);
-                    server.addResource(scriptResource);
-                    server.addResource(scriptMetadataResource);
-                    _a.label = 1;
-                case 1:
-                    _a.trys.push([1, 3, , 4]);
-                    godot = getGodotConnection();
-                    return [4 /*yield*/, godot.connect()];
-                case 2:
-                    _a.sent();
-                    console.error('Successfully connected to Godot WebSocket server');
-                    return [3 /*break*/, 4];
-                case 3:
-                    error_1 = _a.sent();
-                    err = error_1;
-                    console.warn("Could not connect to Godot: ".concat(err.message));
-                    console.warn('Will retry connection when commands are executed');
-                    return [3 /*break*/, 4];
-                case 4:
-                    // Start the server
-                    server.start({
-                        transportType: 'stdio',
-                    });
-                    console.error('Godot MCP server started');
-                    cleanup = function () {
-                        console.error('Shutting down Godot MCP server...');
-                        var godot = getGodotConnection();
-                        godot.disconnect();
-                        process.exit(0);
-                    };
-                    process.on('SIGINT', cleanup);
-                    process.on('SIGTERM', cleanup);
-                    return [2 /*return*/];
-            }
+            console.error('Starting Godot MCP server...');
+            server = new FastMCP({
+                name: 'GodotMCP',
+                version: '1.0.0',
+            });
+            // Register all tools
+            __spreadArray(__spreadArray(__spreadArray(__spreadArray([], nodeTools, true), scriptTools, true), sceneTools, true), editorTools, true).forEach(function (tool) {
+                server.addTool(tool);
+            });
+            // Register all resources
+            // Static resources
+            server.addResource(sceneListResource);
+            server.addResource(scriptListResource);
+            server.addResource(projectStructureResource);
+            server.addResource(projectSettingsResource);
+            server.addResource(projectResourcesResource);
+            server.addResource(editorStateResource);
+            server.addResource(selectedNodeResource);
+            server.addResource(currentScriptResource);
+            server.addResource(sceneStructureResource);
+            server.addResource(scriptResource);
+            server.addResource(scriptMetadataResource);
+            // Start the server first so the MCP handshake isn't blocked by
+            // Godot connection retries (each attempt waits the full timeout)
+            server.start({
+                transportType: 'stdio',
+            });
+            godot = getGodotConnection();
+            godot.connect().then(function () {
+                console.error('Successfully connected to Godot WebSocket server');
+            }).catch(function (error) {
+                var err = error;
+                console.warn("Could not connect to Godot: ".concat(err.message));
+                console.warn('Will retry connection when commands are executed');
+            });
+            console.error('Godot MCP server started');
+            cleanup = function () {
+                console.error('Shutting down Godot MCP server...');
+                var godot = getGodotConnection();
+                godot.disconnect();
+                process.exit(0);
+            };
+            process.on('SIGINT', cleanup);
+            process.on('SIGTERM', cleanup);
+            return [2 /*return*/];
         });
     });
 }

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -57,20 +57,20 @@ async function main() {
   server.addResource(scriptResource);
   server.addResource(scriptMetadataResource);
 
-  // Try to connect to Godot
-  try {
-    const godot = getGodotConnection();
-    await godot.connect();
+  // Start the server first so the MCP handshake isn't blocked by
+  // Godot connection retries (each attempt waits the full timeout)
+  server.start({
+    transportType: 'stdio',
+  });
+
+  // Try to connect to Godot in the background
+  const godot = getGodotConnection();
+  godot.connect().then(() => {
     console.error('Successfully connected to Godot WebSocket server');
-  } catch (error) {
+  }).catch((error) => {
     const err = error as Error;
     console.warn(`Could not connect to Godot: ${err.message}`);
     console.warn('Will retry connection when commands are executed');
-  }
-
-  // Start the server
-  server.start({
-    transportType: 'stdio',
   });
 
   console.error('Godot MCP server started');


### PR DESCRIPTION
## Problem

`main()` awaits the Godot WebSocket connection (including its full retry timeouts) before starting the stdio transport. When the Godot editor isn't running, the MCP client's handshake times out before the server ever responds, so the server fails to load at all — even though it's designed to retry the Godot connection lazily when commands are executed.

## Fix

Start the stdio transport first, then attempt the Godot connection in the background. Connection success/failure is still logged, and the existing lazy-retry behavior on command execution is unchanged.

Tested with Claude Code + Godot 4.6 on Linux: the server now handshakes immediately whether or not the editor is open, and tools work as soon as the editor-side addon is up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)